### PR TITLE
Fix live timer and chart updates for acceleration experiment

### DIFF
--- a/PhysicsLabApp/Services/DataCollector.swift
+++ b/PhysicsLabApp/Services/DataCollector.swift
@@ -28,9 +28,11 @@ final class AccelerometerMagnitudeCollector: DataCollector, ObservableObject {
         isCollecting = true
         startTime = Date()
         sensorManager.startAccelerometerUpdates()
-        timer = Timer.scheduledTimer(withTimeInterval: samplingInterval, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: samplingInterval, repeats: true) { [weak self] _ in
             self?.sample()
         }
+        self.timer = timer
+        RunLoop.main.add(timer, forMode: .common)
     }
 
     func stop() {
@@ -51,6 +53,10 @@ final class AccelerometerMagnitudeCollector: DataCollector, ObservableObject {
               let startTime else { return }
         let elapsed = Date().timeIntervalSince(startTime)
         let sample = SensorSample(timestamp: elapsed, value: magnitude)
-        dataSeries[0].samples.append(sample)
+        var updatedSeries = dataSeries
+        if !updatedSeries.isEmpty {
+            updatedSeries[0].samples.append(sample)
+            dataSeries = updatedSeries
+        }
     }
 }

--- a/codex-physics-app/codex-physics-app/Services/DataCollector.swift
+++ b/codex-physics-app/codex-physics-app/Services/DataCollector.swift
@@ -29,9 +29,11 @@ final class AccelerometerMagnitudeCollector: DataCollector, ObservableObject {
         isCollecting = true
         startTime = Date()
         sensorManager.startAccelerometerUpdates()
-        timer = Timer.scheduledTimer(withTimeInterval: samplingInterval, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: samplingInterval, repeats: true) { [weak self] _ in
             self?.sample()
         }
+        self.timer = timer
+        RunLoop.main.add(timer, forMode: .common)
     }
 
     func stop() {
@@ -52,6 +54,10 @@ final class AccelerometerMagnitudeCollector: DataCollector, ObservableObject {
               let startTime else { return }
         let elapsed = Date().timeIntervalSince(startTime)
         let sample = SensorSample(timestamp: elapsed, value: magnitude)
-        dataSeries[0].samples.append(sample)
+        var updatedSeries = dataSeries
+        if !updatedSeries.isEmpty {
+            updatedSeries[0].samples.append(sample)
+            dataSeries = updatedSeries
+        }
     }
 }

--- a/codex-physics-app/codex-physics-app/ViewModels/ExperimentViewModel.swift
+++ b/codex-physics-app/codex-physics-app/ViewModels/ExperimentViewModel.swift
@@ -4,6 +4,7 @@ import Combine
 // Refine ObservableObject to those using the standard ObservableObjectPublisher
 private protocol DefaultObservableObject: ObservableObject where ObjectWillChangePublisher == ObservableObjectPublisher {}
 
+@MainActor
 final class ExperimentViewModel: ObservableObject {
     let objectWillChange = ObservableObjectPublisher()
     enum Phase {
@@ -20,7 +21,7 @@ final class ExperimentViewModel: ObservableObject {
     private let experiment: any Experiment
     private let sensorManager: SensorManager
     private var dataCollector: DataCollector?
-    private var timerCancellable: AnyCancellable?
+    private var timer: Timer?
     private var collectorCancellable: AnyCancellable?
     private var targetDuration: TimeInterval?
     private var startDate: Date?
@@ -29,6 +30,10 @@ final class ExperimentViewModel: ObservableObject {
         self.experiment = experiment
         self.sensorManager = sensorManager
         configureCollector()
+    }
+
+    deinit {
+        timer?.invalidate()
     }
 
     func start(runMode: ExperimentConfiguration.RunMode, customDuration: TimeInterval? = nil) {
@@ -58,8 +63,8 @@ final class ExperimentViewModel: ObservableObject {
     func stop() {
         guard phase == .running else { return }
         dataCollector?.stop()
-        timerCancellable?.cancel()
-        timerCancellable = nil
+        timer?.invalidate()
+        timer = nil
         phase = .completed
         remainingTime = targetDuration.map { max(0, $0 - elapsedTime) }
     }
@@ -67,6 +72,8 @@ final class ExperimentViewModel: ObservableObject {
     func reset() {
         dataCollector?.stop()
         dataCollector?.reset()
+        timer?.invalidate()
+        timer = nil
         phase = .idle
         elapsedTime = 0
         remainingTime = targetDuration
@@ -96,12 +103,12 @@ final class ExperimentViewModel: ObservableObject {
     }
 
     private func startTimer() {
-        timerCancellable?.cancel()
-        timerCancellable = Timer.publish(every: 0.05, on: .main, in: .common)
-            .autoconnect()
-            .sink { [weak self] date in
-                self?.updateTimers(referenceDate: date)
-            }
+        timer?.invalidate()
+        let timer = Timer(timeInterval: 0.05, repeats: true) { [weak self] _ in
+            self?.updateTimers(referenceDate: Date())
+        }
+        self.timer = timer
+        RunLoop.main.add(timer, forMode: .common)
     }
 
     private func updateTimers(referenceDate date: Date) {


### PR DESCRIPTION
## Summary
- keep experiment view model on the main actor and replace the Combine timer with a common-mode `Timer` so the stopwatch updates smoothly
- ensure accelerometer sampling timers run on the common run loop and publish fresh sensor series snapshots for every sample so charts refresh live
- apply the same fixes to the mirrored target in the repository

## Testing
- not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dd9f453210832aa87c52357bb9f85c